### PR TITLE
feat(ci): build and push frontend and backend docker images

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -61,7 +61,7 @@ jobs:
           uv run tox run -e test
         continue-on-error: true # TODO: remove when there are tests to run
 
-  coverage:
+  test-coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -78,4 +78,23 @@ jobs:
           cd code/backend
           uv run tox run -e coverage
         continue-on-error: true # TODO: remove when there are tests to run
-# TODO: Add docker file image build and push to docker registry
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Log in to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile.backend
+        push: true
+        tags: kickaas/event-manager-backend:latest

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -97,4 +97,4 @@ jobs:
         context: .
         file: Dockerfile.backend
         push: true
-        tags: kickaas/event-manager-backend:latest
+        tags: ${{ secrets.DOCKER_USERNAME }}/event-manager-backend:latest

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -86,4 +86,4 @@ jobs:
         context: .
         file: Dockerfile.frontend
         push: true
-        tags: kickaas/event-manager-frontend:latest
+        tags: ${{ secrets.DOCKER_USERNAME }}/event-manager-frontend:latest

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
-  check-frontend:
+  check:
     name: Check Frontend
     runs-on: ubuntu-latest
     needs: lint
@@ -56,7 +56,7 @@ jobs:
       - name: Run build
         run: npm run build
 
-  hadolint-frontend:
+  hadolint:
     name: Lint frontend Dockerfile
     runs-on: ubuntu-latest
     steps:
@@ -67,3 +67,23 @@ jobs:
         uses: hadolint/hadolint-action@v3.2.0
         with:
           dockerfile: Dockerfile.frontend
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Log in to DockerHub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile.frontend
+        push: true
+        tags: kickaas/event-manager-frontend:latest

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential gcc \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+COPY code/backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY code/backend/ .

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,7 +2,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-RUN apk add --no-cache libc6-compat=1.3.0-r2
+RUN apk add --no-cache libc6-compat
 
 # Copy manifests first for better caching
 COPY code/frontend/package.json code/frontend/package-lock.json ./

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,6 +2,7 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache libc6-compat
 
 # Copy manifests first for better caching


### PR DESCRIPTION
Add new jobs to the frontend and backend ci pipelines to build and push the respective docker images to a docker registry. The docker registry we are using is my personal docker registry for now. However, the team is considering creating a new docker account for this project and use that instead to make sure everyone has access to the docker registry.

Both the DOCKER_USERNAME and DOCKER_ACCESS_TOKEN are saved as secrets in the github repo to avoid external tampering of the images.

Resolves #6 
Resolves #7 