### PR TITLE
ci(gitleaks): add repo config and secret scanning job ; docs: README section for secret scanning

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -78,6 +78,31 @@ jobs:
           cd code/backend
           uv run tox run -e coverage
         continue-on-error: true # TODO: remove when there are tests to run
+  
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks (licensed action)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE_KEY }}
+
+      # Upload to Code Scanning so findings show in Security tab
+      - name: Upload SARIF to Code Scanning
+        if: ${{ always() && hashFiles('gitleaks.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
 
   docker:
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "Gitleaks"
+
+[allowlist]
+paths = ["docs/", "code/backend/.tox/", "code/backend/.ruff_cache/", ".venv/"] # ignore everything under these folders for Gitleaks scan
+regexes = [
+  '''(?i)example(api|secret|token)_?key''',   # ignore matches to these dummy text patterns anywhere
+  '''(?i)dummy(-|_)token'''
+]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cs673f25a2project-cs673a2f25team5/
 │       └─ src/app/globals.css      # Style sheet that should persist across all pages
 ├── docs/                           # event manager plan, proposal, and design docs
 ├── .gitignore                      # files or folder to be ignored by git
+├── .gitleaks.toml                  # Gitleaks configuration (allowlist)
 ├── Dockerfile.backend              # dockerfile with definitions to build the backend image
 ├── team.md                         # team members brief introduction
 └── README.md                       # project documentation
@@ -243,6 +244,19 @@ This project uses [`uv`](https://github.com/astral-sh/uv) for:
 
 ---
 
+## Secret Scanning (Gitleaks)
+
+This repo uses **Gitleaks** to stop secrets (API keys, tokens, etc.) from landing in the codebase.
+
+- **Where it runs:** part of the GitHub Actions workflow in '.github/workflows/backend-ci.yml'
+- **Config:** '.gitleaks.toml' (reduces false positives by ignoring docs/caches and obvious dummy tokens)
+- **Output:** results are uploaded to **Security → Code scanning alerts** and PRs get inline annotations
+- **Permissions:** the workflow grants 'security-events: write' to upload SARIF; it uses the auto-provided 'secrets.GITHUB_TOKEN'
+
+### Setup
+1. Add repo secret **'GITLEAKS_LICENSE_KEY'** (Repo → Settings → Secrets and variables → Actions).
+2. Keep '.gitleaks.toml' at repo root so the scanner picks it up.
+
 ## 🗺️ Roadmap - TODOs
 
 Project Overview & High-Level Requirements: 
@@ -261,5 +275,5 @@ Project Overview & High-Level Requirements:
 - [Next.js](https://nextjs.org/docs)
 - [Pip Audit](https://github.com/pypa/pip-audit)
 - [Semgrep](https://github.com/semgrep/semgrep)
-
+- [Gitleaks](https://github.com/gitleaks/gitleaks)
 ---


### PR DESCRIPTION
## Git Leaks Scan
- Adds a **Gitleaks Secret Scan** job to '.github/workflows/backend-ci.yml' to detect hardcoded secrets in PRs/pushes.
- Uploads findings as **SARIF** to GitHub **Security → Code scanning alerts** for inline PR annotations and triage.
- Introduces '.gitleaks.toml' to reduce false positives (ignores docs/caches and obvious demo tokens).
- Documents setup/usage in README.