### PR TITLE
chore: add a test coverage report job to the backend

### DIFF
--- a/code/backend/tox.ini
+++ b/code/backend/tox.ini
@@ -17,6 +17,17 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands = pytest test/
 
+[testenv:report]
+description = Test coverage and open report
+deps =
+    -r requirements-test.txt
+setenv =
+    PYTHONPATH = {toxinidir}
+allowlist_externals = open
+commands =
+    pytest test/ -v --cov=app --cov-report=html
+    open htmlcov/index.html
+
 [testenv:coverage]
 description = Run tests and check for 70% coverage
 deps =


### PR DESCRIPTION
Add a report job to the tox init file so that can developers can easily look at the test coverage report in html format.